### PR TITLE
feat: support embedded languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-oxc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dprint-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,7 +88,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -124,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "css_dataset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25670139e591f1c2869eb8d0d977028f8d05e859132b4c874ecd02a00d3c9174"
+
+[[package]]
 name = "deno_terminal"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +161,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1d827947704a9495f705d6aeed270fa21a67f825f22902c28f38dc3af7a9ae"
 dependencies = [
  "anyhow",
+ "bumpalo",
+ "hashbrown 0.15.5",
  "indexmap",
+ "rustc-hash",
  "serde",
  "serde_json",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "dprint-core-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675ad2b358481f3cc46202040d64ac7a36c4ade414a696df32e0e45421a6e9f"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -165,12 +194,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "dprint-plugin-json"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ef56b214052af8bb5157d0d1b860e042f938abc9360586414a8ff436739508"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "jsonc-parser",
+ "serde",
+ "text_lines",
+]
+
+[[package]]
+name = "dprint-plugin-markdown"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf049c9fa197cf1c327558f1bf28ba6a16bfce1be5ea681b0b5aeede395af951"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "dprint-plugin-oxc"
 version = "0.13.0"
 dependencies = [
  "anyhow",
  "dprint-core",
  "dprint-development",
+ "dprint-plugin-json",
+ "dprint-plugin-markdown",
+ "malva",
+ "markup_fmt",
  "oxc_allocator",
  "oxc_formatter",
  "oxc_parser",
@@ -235,6 +297,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,15 +323,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -260,6 +354,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jsonc-parser"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b187b7e06feb2c205d8ec71f12cd8f553e33477ec155ebfc34f8daa7f3ae4eab"
 
 [[package]]
 name = "libc"
@@ -274,6 +374,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "malva"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7402fe65a61b31ddfcd60f3d965547baab1f1bbdd4506afa73edabed8ed002af"
+dependencies = [
+ "aho-corasick",
+ "itertools",
+ "memchr",
+ "raffia",
+ "tiny_pretty",
+]
+
+[[package]]
+name = "markup_fmt"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cb640cd04ff332352c815f747692bb594808c6fac1c5a2102ef7f9d5344ab1"
+dependencies = [
+ "aho-corasick",
+ "css_dataset",
+ "itertools",
+ "memchr",
+ "tiny_pretty",
 ]
 
 [[package]]
@@ -352,7 +478,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -363,7 +489,7 @@ checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -372,7 +498,7 @@ version = "0.121.0"
 source = "git+https://github.com/oxc-project/oxc?tag=crates_v0.121.0#6cd513ffaeca12beb6858c685bdbf5c705771663"
 dependencies = [
  "allocator-api2",
- "hashbrown",
+ "hashbrown 0.16.1",
  "oxc_data_structures",
  "rustc-hash",
 ]
@@ -401,7 +527,7 @@ dependencies = [
  "phf",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -456,7 +582,7 @@ dependencies = [
  "oxc_syntax",
  "phf",
  "rustc-hash",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -525,7 +651,7 @@ version = "0.121.0"
 source = "git+https://github.com/oxc-project/oxc?tag=crates_v0.121.0#6cd513ffaeca12beb6858c685bdbf5c705771663"
 dependencies = [
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "oxc_allocator",
  "oxc_estree",
 ]
@@ -608,7 +734,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -640,12 +766,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raffia"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826278ad840a1f047475ac36c40569b953b0b5359b126d7a09058e2a42151f89"
+dependencies = [
+ "raffia_macro",
+ "smallvec",
+]
+
+[[package]]
+name = "raffia_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac21f5e4bc6b29ea5d5e691a9aa08b2b9fd8891f48a99157b9f02d8a48e1318"
+dependencies = [
+ "heck",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -763,7 +921,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -812,6 +970,17 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -831,6 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_lines"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd5828de7deaa782e1dd713006ae96b3bee32d3279b79eb67ecf8072c059bcf"
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +1013,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -858,8 +1033,23 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tiny_pretty"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650d82e943da333637be9f1567d33d605e76810a26464edfd7ae74f7ef181e95"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-id-start"
@@ -884,6 +1074,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,9 @@ serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 dprint-development = "0.10.2"
+dprint-plugin-json = "0.21.1"
+dprint-plugin-markdown = "0.21.1"
+malva = "0.15.2"
+markup_fmt = "0.26.0"
 pretty_assertions = "1.4.0"
 serde_json = { version = "1.0" }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 Adapter for [Oxc](https://github.com/oxc-project/oxc) for use as a formatting plugin in [dprint](https://github.com/dprint/dprint).
 
+This formatter will delegate formatting of embedded languages to other dprint plugins:
+
+- `css` and `styled` tagged template literals will be formatted by [Malva](https://dprint.dev/plugins/malva/)
+- `html` tagged template literals will be formatted by [Markup_fmt](https://dprint.dev/plugins/markup_fmt/)
+- `md` and `markdown` tagged template literals will be formatted by [Markdown Code Formatter](https://dprint.dev/plugins/markdown/)
+
+Unfortunately, GraphQL tagged template literals cannot be supported for now because oxc_formatter uses a different API for GraphQL documents that cannot be delegated to string-based formatters.
+
+You can disable embedded language formatting by setting `embeddedLanguageFormatting` to `"off"` in the plugin's configuration.
+
 ## Install
 
 [Install](https://dprint.dev/install/) and [setup](https://dprint.dev/setup/) dprint.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,6 @@
 
 Adapter for [Oxc](https://github.com/oxc-project/oxc) for use as a formatting plugin in [dprint](https://github.com/dprint/dprint).
 
-This formatter will delegate formatting of embedded languages to other dprint plugins:
-
-- `css` and `styled` tagged template literals will be formatted by [Malva](https://dprint.dev/plugins/malva/)
-- `html` tagged template literals will be formatted by [Markup_fmt](https://dprint.dev/plugins/markup_fmt/)
-- `md` and `markdown` tagged template literals will be formatted by [Markdown Code Formatter](https://dprint.dev/plugins/markdown/)
-
-Unfortunately, GraphQL tagged template literals cannot be supported for now because oxc_formatter uses a different API for GraphQL documents that cannot be delegated to string-based formatters.
-
-You can disable embedded language formatting by setting `embeddedLanguageFormatting` to `"off"` in the plugin's configuration.
-
 ## Install
 
 [Install](https://dprint.dev/install/) and [setup](https://dprint.dev/setup/) dprint.
@@ -46,6 +36,14 @@ To add configuration, specify an `"oxc"` key in your dprint.json:
 For an overview of the config, see https://dprint.dev/plugins/oxc/config/
 
 Note: The plugin does not understand Oxc's configuration file because it runs sandboxed in a Wasm runtime—it has no access to the file system in order to read Oxc's config.
+
+### Embedded Formatting
+
+Unlike oxc, this formatter will delegate formatting of embedded languages to other dprint plugins.
+
+Unfortunately, GraphQL tagged template literals cannot be supported for now because oxc_formatter uses a different API for GraphQL documents that cannot be delegated to string-based formatters.
+
+You can disable embedded language formatting by setting `embeddedLanguageFormatting` to `"off"` in the plugin's configuration.
 
 ## JS Formatting API
 

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -148,7 +148,10 @@ fn resolve_sort_imports_options(
         .into_iter()
         .filter_map(|v| {
           let mut obj = v.into_object()?;
-          let group_name = obj.shift_remove("groupName").and_then(|v| v.into_string()).unwrap_or_default();
+          let group_name = obj
+            .shift_remove("groupName")
+            .and_then(|v| v.into_string())
+            .unwrap_or_default();
           let element_name_pattern = obj
             .shift_remove("elementNamePattern")
             .and_then(|v| v.into_array())

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -3,10 +3,13 @@ use anyhow::bail;
 use oxc_allocator::Allocator;
 use oxc_formatter::ArrowParentheses;
 use oxc_formatter::AttributePosition;
+use oxc_formatter::CustomGroupDefinition;
 use oxc_formatter::EmbeddedLanguageFormatting;
 use oxc_formatter::Expand;
+use oxc_formatter::ExternalCallbacks;
 use oxc_formatter::FormatOptions;
 use oxc_formatter::Formatter;
+use oxc_formatter::GroupEntry;
 use oxc_formatter::IndentStyle;
 use oxc_formatter::IndentWidth;
 use oxc_formatter::LineEnding;
@@ -15,8 +18,6 @@ use oxc_formatter::OperatorPosition;
 use oxc_formatter::QuoteProperties;
 use oxc_formatter::QuoteStyle;
 use oxc_formatter::Semicolons;
-use oxc_formatter::CustomGroupDefinition;
-use oxc_formatter::GroupEntry;
 use oxc_formatter::SortImportsOptions;
 use oxc_formatter::SortOrder;
 use oxc_formatter::SortTailwindcssOptions;
@@ -28,7 +29,12 @@ use std::path::Path;
 
 use crate::configuration::Configuration;
 
-pub fn format_text(file_path: &Path, input_text: &str, config: &Configuration) -> Result<Option<String>> {
+pub fn format_text(
+  file_path: &Path,
+  input_text: &str,
+  config: &Configuration,
+  external_callbacks: Option<ExternalCallbacks>,
+) -> Result<Option<String>> {
   let source_type = match SourceType::from_path(file_path) {
     Ok(source_type) => source_type,
     Err(_) => return Ok(None),
@@ -56,7 +62,12 @@ pub fn format_text(file_path: &Path, input_text: &str, config: &Configuration) -
 
   let options = build_format_options(config);
   let formatter = Formatter::new(&allocator, options);
-  let output = formatter.build(&parsed.program);
+
+  let output = formatter
+    .format_with_external_callbacks(&parsed.program, external_callbacks)
+    .print()
+    .unwrap()
+    .into_code();
 
   if output == input_text {
     Ok(None)
@@ -84,14 +95,16 @@ fn build_format_options(config: &Configuration) -> FormatOptions {
   }
 
   if let Some(value) = config.indent_width
-    && let Ok(width) = IndentWidth::try_from(value) {
-      options.indent_width = width;
-    }
+    && let Ok(width) = IndentWidth::try_from(value)
+  {
+    options.indent_width = width;
+  }
 
   if let Some(value) = config.line_width
-    && let Ok(width) = LineWidth::try_from(value) {
-      options.line_width = width;
-    }
+    && let Ok(width) = LineWidth::try_from(value)
+  {
+    options.line_width = width;
+  }
 
   if let Some(semicolons) = config.semicolons {
     options.semicolons = match semicolons {
@@ -192,9 +205,11 @@ fn build_format_options(config: &Configuration) -> FormatOptions {
       ignore_case: sort_imports.ignore_case.unwrap_or(true),
       newlines_between: sort_imports.newlines_between.unwrap_or(true),
       internal_pattern: sort_imports.internal_pattern.clone(),
-      groups: sort_imports.groups.iter().map(|group| {
-        group.iter().map(|s| GroupEntry::parse(s)).collect()
-      }).collect(),
+      groups: sort_imports
+        .groups
+        .iter()
+        .map(|group| group.iter().map(|s| GroupEntry::parse(s)).collect())
+        .collect(),
       custom_groups: sort_imports
         .custom_groups
         .iter()
@@ -230,7 +245,7 @@ mod test {
   fn formats_basic_js() {
     let input = "const x=1";
     let config = crate::configuration::Configuration::default();
-    let result = format_text(std::path::Path::new("test.js"), input, &config)
+    let result = format_text(std::path::Path::new("test.js"), input, &config, None)
       .unwrap()
       .unwrap();
     assert_eq!(result, "const x = 1;\n");

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -239,6 +239,8 @@ fn build_format_options(config: &Configuration) -> FormatOptions {
 
 #[cfg(test)]
 mod test {
+  use std::sync::Arc;
+
   use super::*;
 
   #[test]
@@ -249,5 +251,25 @@ mod test {
       .unwrap()
       .unwrap();
     assert_eq!(result, "const x = 1;\n");
+  }
+
+  #[test]
+  fn formats_embedded_css() {
+    let input = "const styles=css`.foo{color:red}`;";
+    let config = crate::configuration::Configuration::default();
+    let result = format_text(
+      std::path::Path::new("test.js"),
+      input,
+      &config,
+      Some(
+        ExternalCallbacks::new().with_embedded_formatter(Some(Arc::new(|language, code| {
+          // Dummy formatter for testing
+          Ok(format!("formatted_{}_{}", language, code.replace('\n', "\\n")))
+        }))),
+      ),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(result, "const styles = formatted_tagged-css_.foo{color:red};\n");
   }
 }

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -270,6 +270,12 @@ mod test {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(result, "const styles = formatted_tagged-css_.foo{color:red};\n");
+    assert_eq!(
+      result,
+      "const styles = css`
+  formatted_tagged-css_.foo{color:red}
+`;
+"
+    );
   }
 }

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -254,8 +254,9 @@ mod test {
   }
 
   #[test]
-  fn formats_embedded_css() {
-    let input = "const styles=css`.foo{color:red}`;";
+  fn formats_embedded_html() {
+    // Uses html`` tag which goes through the string-based format_embedded path
+    let input = "const template=html`<div>hello</div>`;";
     let config = crate::configuration::Configuration::default();
     let result = format_text(
       std::path::Path::new("test.js"),
@@ -272,8 +273,8 @@ mod test {
     .unwrap();
     assert_eq!(
       result,
-      "const styles = css`
-  formatted_tagged-css_.foo{color:red}
+      "const template = html`
+  formatted_tagged-html_<div>hello</div>
 `;
 "
     );

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -66,7 +66,7 @@ pub fn format_text(
   let output = formatter
     .format_with_external_callbacks(&parsed.program, external_callbacks)
     .print()
-    .unwrap()
+    .map_err(|e| anyhow::anyhow!("Failed to print formatted output: {}", e))?
     .into_code();
 
   if output == input_text {

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -1,3 +1,7 @@
+use std::cell::UnsafeCell;
+use std::path::Path;
+use std::sync::Arc;
+
 use super::configuration::Configuration;
 use super::configuration::resolve_config;
 
@@ -13,6 +17,27 @@ use dprint_core::plugins::PluginResolveConfigurationResult;
 use dprint_core::plugins::SyncFormatRequest;
 use dprint_core::plugins::SyncHostFormatRequest;
 use dprint_core::plugins::SyncPluginHandler;
+use oxc_formatter::EmbeddedFormatterCallback;
+use oxc_formatter::ExternalCallbacks;
+
+// This is ok to do because Wasm plugins are executed on a single thread
+struct WasmCallback<T>(UnsafeCell<T>);
+
+unsafe impl<T> Send for WasmCallback<T> {}
+unsafe impl<T> Sync for WasmCallback<T> {}
+
+impl<T> WasmCallback<T> {
+  fn new(value: T) -> Self {
+    WasmCallback(UnsafeCell::new(value))
+  }
+
+  fn call<Args, Output>(&self, args: Args) -> Output
+  where
+    T: FnMut(Args) -> Output,
+  {
+    (unsafe { &mut *self.0.get() })(args)
+  }
+}
 
 struct OxcPluginHandler;
 
@@ -69,14 +94,47 @@ impl SyncPluginHandler<Configuration> for OxcPluginHandler {
   fn format(
     &mut self,
     request: SyncFormatRequest<Configuration>,
-    _format_with_host: impl FnMut(SyncHostFormatRequest) -> FormatResult,
+    format_with_host: impl FnMut(SyncHostFormatRequest) -> FormatResult,
   ) -> FormatResult {
     if request.range.is_some() {
       return Ok(None); // not implemented
     }
 
+    let override_config = ConfigKeyMap::new();
+    let format_callback = WasmCallback::new(format_with_host);
+
+    // SAFETY: The embedded_formatter closure is only used synchronously within format_text
+    // and does not escape. The 'static bound on EmbeddedFormatterCallback is overly
+    // restrictive for this use case. We know format_with_host lives for the duration
+    // of this function call, which is longer than the format_text call.
+    let embedded_formatter: EmbeddedFormatterCallback = unsafe {
+      std::mem::transmute::<
+        Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>,
+        Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync + 'static>,
+      >(Arc::new(move |language: &str, text: &str| {
+        let file_path = format!("/tmp/embedded.{}", language);
+        let request = SyncHostFormatRequest {
+          file_path: Path::new(&file_path),
+          file_bytes: text.as_bytes(),
+          range: None,
+          override_config: &override_config,
+        };
+
+        match format_callback.call(request) {
+          Ok(Some(bytes)) => String::from_utf8(bytes).map_err(|e| e.to_string()),
+          Ok(None) => Ok(text.to_string()),
+          Err(e) => Err(e.to_string()),
+        }
+      }))
+    };
+
     let text = String::from_utf8_lossy(&request.file_bytes);
-    let maybe_text = super::format_text(request.file_path, &text, request.config)?;
+    let maybe_text = super::format_text(
+      request.file_path,
+      &text,
+      request.config,
+      Some(ExternalCallbacks::new().with_embedded_formatter(Some(embedded_formatter))),
+    )?;
     Ok(maybe_text.map(|t| t.into_bytes()))
   }
 }

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -20,7 +20,9 @@ use dprint_core::plugins::SyncPluginHandler;
 use oxc_formatter::EmbeddedFormatterCallback;
 use oxc_formatter::ExternalCallbacks;
 
-// This is ok to do because Wasm plugins are executed on a single thread
+// This is ok to do because Wasm plugins are executed on a single thread.
+// Same pattern as used in generate_plugin_code! macro.
+// https://github.com/dprint/dprint/blob/2e839405dcf75541bb3b59978c804304fedaa581/crates/core/src/plugins/wasm/mod.rs#L89-L114
 struct WasmCallback<T>(UnsafeCell<T>);
 
 unsafe impl<T> Send for WasmCallback<T> {}
@@ -36,6 +38,20 @@ impl<T> WasmCallback<T> {
     T: FnMut(Args) -> Output,
   {
     (unsafe { &mut *self.0.get() })(args)
+  }
+}
+
+// Adapted from oxc-project/oxc
+// https://github.com/oxc-project/oxc/blob/50eb16052247694e483828b2a603ade5e410c569/apps/oxfmt/src/core/external_formatter.rs#L362-L375
+fn language_to_extension(language: &str) -> &'static str {
+  match language {
+    "tagged-css" | "styled-jsx" => "scss",
+    "tagged-graphql" => "gql", // Not used, oxc will always use format_embedded_doc
+    "tagged-html" => "html",
+    "tagged-markdown" => "md",
+    "angular-template" => "component.html", // Extension used by markup_fmt
+    "angular-styles" => "scss",
+    _ => "txt",
   }
 }
 
@@ -112,7 +128,7 @@ impl SyncPluginHandler<Configuration> for OxcPluginHandler {
         Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>,
         Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync + 'static>,
       >(Arc::new(move |language: &str, text: &str| {
-        let file_path = format!("/tmp/embedded.{}", language);
+        let file_path = format!("/tmp/embedded.{}", language_to_extension(language));
         let request = SyncHostFormatRequest {
           file_path: Path::new(&file_path),
           file_bytes: text.as_bytes(),
@@ -123,7 +139,7 @@ impl SyncPluginHandler<Configuration> for OxcPluginHandler {
         match format_callback.call(request) {
           Ok(Some(bytes)) => String::from_utf8(bytes).map_err(|e| e.to_string()),
           Ok(None) => Ok(text.to_string()),
-          Err(e) => Err(e.to_string()),
+          Err(e) => Err(format!("Failed to format embedded {}: {:#}", language, e)),
         }
       }))
     };

--- a/tests/specs/ConfigArrowParenthesesAlways.txt
+++ b/tests/specs/ConfigArrowParenthesesAlways.txt
@@ -1,0 +1,6 @@
+~~ arrowParentheses: always ~~
+== should add parens for single param ==
+const f = x => x;
+
+[expect]
+const f = (x) => x;

--- a/tests/specs/ConfigArrowParenthesesAsNeeded.txt
+++ b/tests/specs/ConfigArrowParenthesesAsNeeded.txt
@@ -1,0 +1,6 @@
+~~ arrowParentheses: asNeeded ~~
+== should omit parens for single param ==
+const f = (x) => x;
+
+[expect]
+const f = x => x;

--- a/tests/specs/ConfigIndentSpaces.txt
+++ b/tests/specs/ConfigIndentSpaces.txt
@@ -1,0 +1,10 @@
+~~ indentStyle: space, indentWidth: 4 ~~
+== should indent with 4 spaces ==
+function foo() {
+const x = 1;
+}
+
+[expect]
+function foo() {
+    const x = 1;
+}

--- a/tests/specs/ConfigIndentTabs.txt
+++ b/tests/specs/ConfigIndentTabs.txt
@@ -1,0 +1,10 @@
+~~ indentStyle: tab ~~
+== should indent with tabs ==
+function foo() {
+const x = 1;
+}
+
+[expect]
+function foo() {
+	const x = 1;
+}

--- a/tests/specs/ConfigQuoteStyleDouble.txt
+++ b/tests/specs/ConfigQuoteStyleDouble.txt
@@ -1,0 +1,8 @@
+~~ quoteStyle: double ~~
+== should use double quotes ==
+const x = 'hello';
+const y = 'world';
+
+[expect]
+const x = "hello";
+const y = "world";

--- a/tests/specs/ConfigQuoteStyleSingle.txt
+++ b/tests/specs/ConfigQuoteStyleSingle.txt
@@ -1,0 +1,8 @@
+~~ quoteStyle: single ~~
+== should use single quotes ==
+const x = "hello";
+const y = "world";
+
+[expect]
+const x = 'hello';
+const y = 'world';

--- a/tests/specs/ConfigTrailingCommasAll.txt
+++ b/tests/specs/ConfigTrailingCommasAll.txt
@@ -1,0 +1,10 @@
+~~ trailingCommas: all, lineWidth: 40 ~~
+== should add trailing commas ==
+function foo(aaaa: number, bbbb: number, cccc: string) {}
+
+[expect]
+function foo(
+  aaaa: number,
+  bbbb: number,
+  cccc: string,
+) {}

--- a/tests/specs/ConfigTrailingCommasNone.txt
+++ b/tests/specs/ConfigTrailingCommasNone.txt
@@ -1,0 +1,10 @@
+~~ trailingCommas: none, lineWidth: 40 ~~
+== should remove trailing commas ==
+function foo(aaaa: number, bbbb: number, cccc: string,) {}
+
+[expect]
+function foo(
+  aaaa: number,
+  bbbb: number,
+  cccc: string
+) {}

--- a/tests/specs/EmbeddedHtml.txt
+++ b/tests/specs/EmbeddedHtml.txt
@@ -1,0 +1,7 @@
+== should format embedded html in tagged template ==
+const template = html`<div><span>hello</span></div>`;
+
+[expect]
+const template = html`
+  <div><span>hello</span></div>
+`;

--- a/tests/specs/EmbeddedMarkdown.txt
+++ b/tests/specs/EmbeddedMarkdown.txt
@@ -1,0 +1,10 @@
+== should format embedded markdown in tagged template ==
+const docs = md`# Hello
+This is a   test.`;
+
+[expect]
+const docs = md`
+  # Hello
+
+  This is a test.
+`;

--- a/tests/specs/ExtensionsCjs.txt
+++ b/tests/specs/ExtensionsCjs.txt
@@ -1,0 +1,6 @@
+-- file.cjs --
+== should format cjs ==
+const   x=1
+
+[expect]
+const x = 1;

--- a/tests/specs/ExtensionsCts.txt
+++ b/tests/specs/ExtensionsCts.txt
@@ -1,0 +1,6 @@
+-- file.cts --
+== should format cts ==
+const   x:number=1
+
+[expect]
+const x: number = 1;

--- a/tests/specs/ExtensionsJs.txt
+++ b/tests/specs/ExtensionsJs.txt
@@ -1,0 +1,6 @@
+-- file.js --
+== should format js ==
+const   x=1
+
+[expect]
+const x = 1;

--- a/tests/specs/ExtensionsJsx.txt
+++ b/tests/specs/ExtensionsJsx.txt
@@ -1,0 +1,6 @@
+-- file.jsx --
+== should format jsx ==
+const el=<div>hi</div>
+
+[expect]
+const el = <div>hi</div>;

--- a/tests/specs/ExtensionsMjs.txt
+++ b/tests/specs/ExtensionsMjs.txt
@@ -1,0 +1,6 @@
+-- file.mjs --
+== should format mjs ==
+const   x=1
+
+[expect]
+const x = 1;

--- a/tests/specs/ExtensionsMts.txt
+++ b/tests/specs/ExtensionsMts.txt
@@ -1,0 +1,6 @@
+-- file.mts --
+== should format mts ==
+const   x:number=1
+
+[expect]
+const x: number = 1;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,8 @@
 extern crate dprint_development;
 extern crate dprint_plugin_oxc;
 
+use std::borrow::Cow;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -9,6 +11,33 @@ use dprint_development::*;
 use dprint_plugin_oxc::configuration::Configuration;
 use dprint_plugin_oxc::configuration::resolve_config;
 use dprint_plugin_oxc::*;
+use oxc_formatter::ExternalCallbacks;
+
+fn make_external_callbacks() -> ExternalCallbacks {
+  let css_config = malva::config::FormatOptions::default();
+  ExternalCallbacks::new().with_embedded_formatter(Some(Arc::new(move |language, code| {
+    match language {
+      "tagged-css" | "styled-jsx" | "angular-styles" => {
+        malva::format_text(code, malva::Syntax::Scss, &css_config).map_err(|e| format!("{e}"))
+      }
+      "tagged-html" | "angular-template" => {
+        let html_opts = markup_fmt::config::FormatOptions::default();
+        markup_fmt::format_text(code, markup_fmt::Language::Html, &html_opts, |code, _| {
+          Ok::<_, std::convert::Infallible>(Cow::Borrowed(code))
+        })
+        .map_err(|e| format!("{e}"))
+      }
+      "tagged-markdown" => {
+        let md_config =
+          dprint_plugin_markdown::configuration::ConfigurationBuilder::new().build();
+        dprint_plugin_markdown::format_text(code, &md_config, |_, _, _| Ok(None))
+          .map(|r| r.unwrap_or_else(|| code.to_string()))
+          .map_err(|e| format!("{e}"))
+      }
+      _ => Ok(code.to_string()),
+    }
+  })))
+}
 
 #[test]
 fn test_specs() {
@@ -30,7 +59,12 @@ fn test_specs() {
         let config_result = resolve_config(spec_config, &global_config);
         ensure_no_diagnostics(&config_result.diagnostics);
 
-        format_text(file_path, &file_text, &config_result.config, None)
+        format_text(
+          file_path,
+          &file_text,
+          &config_result.config,
+          Some(make_external_callbacks()),
+        )
       })
     },
     Arc::new(move |_file_path, _file_text, _spec_config| panic!("Plugin does not support dprint-core tracing.")),
@@ -43,4 +77,17 @@ fn should_fail_on_parse_error_js() {
   let err = format_text(&PathBuf::from("./file.ts"), "const t string = 5;", &config, None).unwrap_err();
   // Just verify that it returns an error for invalid syntax
   assert!(!err.to_string().is_empty());
+}
+
+#[test]
+fn format_with_json_plugin() {
+  // Verify dprint-plugin-json can format JSON (oxc doesn't handle .json files)
+  let input = r#"{"hello":   "world","num":42}"#;
+  let json_config = dprint_plugin_json::configuration::ConfigurationBuilder::new().build();
+  let result = dprint_plugin_json::format_text(Path::new("test.json"), input, &json_config)
+    .unwrap()
+    .unwrap();
+  assert!(result.contains("\"hello\": \"world\""));
+  let _: serde_json::Value =
+    serde_json::from_str(&result).expect("dprint-plugin-json output should be valid JSON");
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,7 +30,7 @@ fn test_specs() {
         let config_result = resolve_config(spec_config, &global_config);
         ensure_no_diagnostics(&config_result.diagnostics);
 
-        format_text(file_path, &file_text, &config_result.config)
+        format_text(file_path, &file_text, &config_result.config, None)
       })
     },
     Arc::new(move |_file_path, _file_text, _spec_config| panic!("Plugin does not support dprint-core tracing.")),
@@ -40,7 +40,7 @@ fn test_specs() {
 #[test]
 fn should_fail_on_parse_error_js() {
   let config = Configuration::default();
-  let err = format_text(&PathBuf::from("./file.ts"), "const t string = 5;", &config).unwrap_err();
+  let err = format_text(&PathBuf::from("./file.ts"), "const t string = 5;", &config, None).unwrap_err();
   // Just verify that it returns an error for invalid syntax
   assert!(!err.to_string().is_empty());
 }


### PR DESCRIPTION
Hi!

This is my attempt at fixing #6, with a LOT of assistance from Copilot

I carefully reviewed the code produced, but this reaches farther than my rust knowledge; Copilot declared that the `std::mem::transmute` call was the sanest way to tell the compiler not to worry about lifetimes, but it's my first time using this API

Please close this PR if the code is too bad, don't take the time to review slop it's not worth it

I opened https://github.com/oxc-project/oxc/pull/20040 to see if we could also format embedded graphql with https://dprint.dev/plugins/pretty_graphql/

Have a nice day :)
