### PR TITLE
chore: AI-assisted Oxc update fixing and review

### DIFF
--- a/.github/workflows/check_updates.yml
+++ b/.github/workflows/check_updates.yml
@@ -22,7 +22,23 @@ jobs:
       - uses: denoland/setup-deno@v2
       - uses: dsherret/rust-toolchain-file@v1
 
+      # the update script builds the wasm release as one of its checks.
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      # node is needed so the update script can install and run the OpenAI
+      # Codex CLI (@openai/codex) when it has to reconcile an Oxc update.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
       - name: Run script
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # model that fixes/wires up the Oxc update (Codex)
+          CODEX_MODEL: gpt-5.6-terra
+          # separate model that independently reviews the changes
+          REVIEW_MODEL: gpt-5.6-sol
         run: |
           git config user.email "dprintbot@users.noreply.github.com"
           git config user.name "dprintbot"

--- a/deno.lock
+++ b/deno.lock
@@ -14,6 +14,7 @@
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/semver@1": "1.0.7",
     "jsr:@std/streams@0.221": "0.221.0",
+    "jsr:@std/yaml@1": "1.1.2",
     "npm:octokit@^3.1.0": "3.2.2_@octokit+core@5.2.2"
   },
   "jsr": {
@@ -79,6 +80,9 @@
       "dependencies": [
         "jsr:@std/io"
       ]
+    },
+    "@std/yaml@1.1.2": {
+      "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
     }
   },
   "npm": {

--- a/scripts/ai_fix.ts
+++ b/scripts/ai_fix.ts
@@ -1,0 +1,287 @@
+/**
+ * Reconciles this plugin with a new Oxc release using OpenAI Codex, in two
+ * stages that each run Codex with a different model:
+ *
+ *   1. a Codex agentic session edits the source and runs the checks until they
+ *      pass (fixing breakage and/or wiring up new formatter options), then
+ *   2. a SEPARATE reviewer model reviews the result with Codex, so it can
+ *      investigate (read the upstream oxc source, grep the repo). It is
+ *      instructed to review only and not modify anything. If it finds blocking
+ *      issues they are fed back to the stage-1 Codex for another pass, bounded
+ *      by `REVIEW_MAX_ROUNDS`. If it still isn't approved, this throws so the
+ *      workflow fails and nothing is published.
+ *
+ * Two situations call this:
+ *   - a patch bump that failed the checks (fix the breakage), and
+ *   - any minor bump (review for new/renamed/removed options even when it
+ *     still compiles).
+ *
+ * Codex must NOT commit or push -- `update.ts` captures the working tree
+ * changes into the existing Oxc bump commit afterwards.
+ */
+import { $ } from "automation";
+
+export interface AiFixOptions {
+  /** true for a patch bump, false for a minor/major bump. */
+  isPatchBump: boolean;
+  /** Oxc tag currently in Cargo.toml (before the bump). */
+  fromVersion: string;
+  /** Oxc tag being upgraded to. */
+  toVersion: string;
+  /** Whether the checks (test + clippy + wasm build) already passed. */
+  checksPassed: boolean;
+  /** Combined output of the failing checks (empty when `checksPassed`). */
+  checkOutput: string;
+}
+
+/** Max number of times the reviewer may send changes back to Codex. */
+const REVIEW_MAX_ROUNDS = 2;
+
+export async function aiFixOxcUpdate(options: AiFixOptions): Promise<void> {
+  const apiKey = requireApiKey();
+  await ensureCodexInstalled();
+  await codexLogin(apiKey);
+
+  // stage 1: let Codex reconcile the update.
+  await runCodex(buildFixPrompt(options));
+
+  // stage 2: independent second-model review, with a bounded refix loop.
+  for (let round = 1;; round++) {
+    const review = await reviewChanges(options);
+    logReview(review);
+    if (review.approved) {
+      return;
+    }
+    if (round > REVIEW_MAX_ROUNDS) {
+      const blocking = review.issues.filter((i) => i.severity === "blocking");
+      throw new Error(
+        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n` +
+          blocking.map((i) => `  - ${i.description}`).join("\n"),
+      );
+    }
+    $.logStep(`Reviewer requested changes — Codex refix round ${round}...`);
+    await runCodex(buildRefixPrompt(review));
+  }
+}
+
+// stage 1: Codex ---------------------------------------------------------------
+
+async function runCodex(prompt: string): Promise<void> {
+  const args = ["exec", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check"];
+  const model = Deno.env.get("CODEX_MODEL");
+  if (model) {
+    args.push("--model", model);
+  }
+  args.push(prompt);
+
+  $.logStep("Running Codex...");
+  await $`codex ${args}`;
+}
+
+function buildFixPrompt(options: AiFixOptions): string {
+  const { isPatchBump, fromVersion, toVersion, checksPassed, checkOutput } = options;
+
+  const situation = checksPassed
+    ? `Oxc was upgraded from ${fromVersion} to ${toVersion} (a ${
+      isPatchBump ? "patch" : "minor"
+    } bump). The project already compiles and the checks pass, but a new Oxc version may have ADDED, RENAMED, or REMOVED formatter options that should be surfaced by this plugin.`
+    : `Oxc was upgraded from ${fromVersion} to ${toVersion} and the checks fail (the project no longer builds, or \`cargo test\` or \`cargo clippy\` fails). This is almost always because oxc's formatter API (its \`JsFormatOptions\` struct or related option enums) changed.`;
+
+  const failureOutput = checkOutput.trim().length > 0
+    ? [
+      ``,
+      `The checks currently fail with the output below. Use it as your starting point instead of re-running the checks just to rediscover the errors:`,
+      "```",
+      truncateHead(checkOutput.trim()),
+      "```",
+    ]
+    : [];
+
+  return [
+    `You are updating the "dprint-plugin-oxc" Rust crate, a dprint plugin that wraps oxc's formatter (\`oxc_formatter\`) to format JavaScript/TypeScript.`,
+    ``,
+    situation,
+    ...failureOutput,
+    ``,
+    `Your goal: make the checks pass AND keep this plugin's configuration surface in sync with oxc's \`JsFormatOptions\`. Do NOT commit or push; only edit files in the working tree.`,
+    ``,
+    describeWiring(),
+    ``,
+    `To see exactly what changed in oxc, inspect the checked-out oxc source that cargo already downloaded (oxc is a git dependency), e.g.:`,
+    `  find ~/.cargo/git/checkouts -maxdepth 4 -type d -name 'oxc_formatter'`,
+    `then read the \`JsFormatOptions\` struct and the option enums in \`oxc_formatter\` (and the shared types in \`oxc_formatter_core\`). Compare that against \`build_format_options\` in \`src/format_text.rs\`.`,
+    ``,
+    `Rules:`,
+    `1. If an option was RENAMED or REMOVED in \`JsFormatOptions\`, update the mapping in \`src/format_text.rs\` (and remove/rename the corresponding plugin config in the other files if it no longer exists upstream).`,
+    `2. If an option was ADDED in \`JsFormatOptions\`, expose it as a new plugin config option across ALL of: \`configuration.rs\`, \`resolve_config.rs\`, \`format_text.rs\`, and \`deployment/schema.json\`. Match the existing naming conventions (Rust snake_case fields, camelCase dprint keys).`,
+    `3. Do NOT edit \`README.md\`. Its config documentation is maintained separately, so leave it untouched.`,
+    `4. Preserve the existing code style. Keep non-test code above test modules. New comments start lowercase unless multiple sentences.`,
+    `5. When done, ALL of these must pass (CI denies clippy warnings, and the wasm build is what actually ships) — iterate until they are all clean:`,
+    `     cargo test`,
+    `     cargo clippy --all-targets --all-features -- -D warnings`,
+    `     cargo build --target wasm32-unknown-unknown --features wasm --release`,
+    `6. Do not change the plugin's own version in Cargo.toml, do not run git commit, and do not push.`,
+  ].join("\n");
+}
+
+function buildRefixPrompt(review: ReviewResult): string {
+  return [
+    `An independent reviewer examined your changes to dprint-plugin-oxc and found issues that must be fixed. Address every blocking issue below, keeping \`cargo test\` green. Do not commit or push.`,
+    ``,
+    `Reviewer summary: ${review.summary}`,
+    ``,
+    `Issues:`,
+    ...review.issues.map((i) => `  - [${i.severity}] ${i.description}`),
+    ``,
+    describeWiring(),
+  ].join("\n");
+}
+
+function describeWiring(): string {
+  return [
+    `How the plugin is wired (keep all of these consistent with each other):`,
+    `- \`src/format_text.rs\` -> \`build_format_options\` maps this plugin's \`Configuration\` onto oxc's \`JsFormatOptions\` (direct field assignment) and its option enums (\`ArrowParentheses\`, \`AttributePosition\`, \`EmbeddedLanguageFormatting\`, \`Expand\`, \`OperatorPosition\`, \`QuoteProperties\`, \`QuoteStyle\`, \`Semicolons\`, \`TrailingCommas\`, \`SortOrder\`), the \`oxc_formatter_core\` types (\`IndentStyle\`, \`IndentWidth\`, \`LineEnding\`, \`LineWidth\`), and nested option structs (\`SortImportsOptions\`, \`SortTailwindcssOptions\`, \`CustomGroupDefinition\`, \`GroupEntry\`).`,
+    `- \`src/configuration/configuration.rs\` -> the plugin's own \`Configuration\` struct and enums.`,
+    `- \`src/configuration/resolve_config.rs\` -> reads each dprint config key (camelCase) into \`Configuration\`.`,
+    `- \`deployment/schema.json\` -> the JSON schema of config options shown to users.`,
+  ].join("\n");
+}
+
+// keep the tail of long check output -- the errors and the "could not compile"
+// summary are at the end, which is the most useful part for the AI.
+function truncateHead(text: string, max = 20_000): string {
+  return text.length > max ? `... (truncated)\n${text.slice(text.length - max)}` : text;
+}
+
+// stage 2: independent reviewer ------------------------------------------------
+
+interface ReviewResult {
+  approved: boolean;
+  summary: string;
+  issues: ReviewIssue[];
+}
+
+interface ReviewIssue {
+  severity: "blocking" | "nit";
+  description: string;
+}
+
+// The reviewer runs Codex too so it can actually investigate (read the oxc
+// source cargo downloaded, grep the repo, verify option names against the real
+// upstream API). Its verdict is captured as JSON via --output-last-message.
+//
+// NOTE: we deliberately do NOT use `--sandbox read-only` here. That makes Codex
+// wrap commands in bubblewrap, which cannot set up its network namespace on the
+// GitHub Actions runner ("bwrap: loopback: Failed RTM_NEWADDR: Operation not
+// permitted"), so every command the reviewer runs fails before executing. We
+// use the same no-sandbox mode as the fixer and enforce read-only via the
+// prompt instead. (CI is itself a throwaway VM, and the final check gate in
+// update.ts re-verifies whatever ends up in the working tree.)
+async function reviewChanges(options: AiFixOptions): Promise<ReviewResult> {
+  // default to a different model than the Codex fixer so the review is a
+  // genuinely independent second opinion.
+  const model = Deno.env.get("REVIEW_MODEL") ?? "gpt-5.6-sol";
+
+  // record intent-to-add so any files Codex created also show in `git diff`.
+  await $`git add -N .`.quiet();
+
+  const outputFile = await Deno.makeTempFile({ prefix: "codex-review-", suffix: ".json" });
+  try {
+    $.logStep(`Reviewing changes with Codex (${model})...`);
+    const args = [
+      "exec",
+      "--skip-git-repo-check",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--model",
+      model,
+      "--output-last-message",
+      outputFile,
+      buildReviewPrompt(options),
+    ];
+    await $`codex ${args}`;
+    return parseReview(await Deno.readTextFile(outputFile));
+  } finally {
+    await Deno.remove(outputFile).catch(() => {});
+  }
+}
+
+function buildReviewPrompt(options: AiFixOptions): string {
+  return [
+    `You are an independent reviewer for dprint-plugin-oxc, a dprint plugin that wraps oxc's formatter to format JavaScript/TypeScript. Oxc was just upgraded from ${options.fromVersion} to ${options.toVersion} and another AI edited this plugin to reconcile it. Review the UNCOMMITTED working-tree changes.`,
+    `IMPORTANT: this is REVIEW ONLY. Read any files and run read-only commands (git diff, cat, grep, find, etc.) to investigate, but you MUST NOT edit, create, or delete any files, and MUST NOT run git commit or git push. Leave the working tree exactly as you found it.`,
+    ``,
+    `Investigate as needed:`,
+    `- Run \`git --no-pager diff\` (and \`git status\`) to see exactly what changed, including any new files.`,
+    `- Verify against the REAL oxc ${options.toVersion} API by reading the source cargo downloaded (oxc is a git dependency):`,
+    `    find ~/.cargo/git/checkouts -maxdepth 4 -type d -name 'oxc_formatter'`,
+    `  then read the \`JsFormatOptions\` struct and option enums in \`oxc_formatter\` and \`oxc_formatter_core\`.`,
+    `- Read the plugin files to confirm they are consistent with each other and with upstream.`,
+    ``,
+    describeWiring(),
+    ``,
+    `Verify specifically:`,
+    `- Every field assigned on \`JsFormatOptions\` in \`build_format_options\` still exists with that exact name (catch removed/renamed options).`,
+    `- Any formatter option newly added upstream is exposed through ALL layers: configuration.rs, resolve_config.rs, format_text.rs, and deployment/schema.json. A partial addition is a blocking issue.`,
+    `- Naming conventions are consistent (Rust snake_case fields, camelCase dprint keys, matching the schema).`,
+    `- README.md was NOT modified (its documentation is maintained separately); flag any README.md change as a blocking issue.`,
+    `- No obvious correctness bugs, and code style matches the surrounding code.`,
+    ``,
+    `When done, your FINAL message must be ONLY a JSON object (no markdown code fences, no extra prose) of exactly this shape:`,
+    `{"approved": true|false, "summary": "one sentence", "issues": [{"severity": "blocking"|"nit", "description": "..."}]}`,
+    `Set approved=false if there is any blocking issue; nits alone do not block.`,
+  ].join("\n");
+}
+
+function parseReview(message: string): ReviewResult {
+  const review = JSON.parse(extractJsonObject(message)) as ReviewResult;
+  if (typeof review.approved !== "boolean" || !Array.isArray(review.issues)) {
+    throw new Error(`Codex review returned malformed JSON:\n${message}`);
+  }
+  return review;
+}
+
+// Codex is instructed to emit only JSON, but tolerate an accidental code fence
+// or surrounding prose by extracting the outermost { ... } object.
+function extractJsonObject(text: string): string {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`Could not find a JSON object in Codex review output:\n${text}`);
+  }
+  return text.slice(start, end + 1);
+}
+
+function logReview(review: ReviewResult): void {
+  $.log(`Review: ${review.approved ? "approved" : "changes requested"} — ${review.summary}`);
+  for (const issue of review.issues) {
+    $.logLight(`  [${issue.severity}] ${issue.description}`);
+  }
+}
+
+// setup ------------------------------------------------------------------------
+
+function requireApiKey(): string {
+  const apiKey = Deno.env.get("OPENAI_API_KEY");
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set. It is required to run the AI fixer and reviewer.");
+  }
+  return apiKey;
+}
+
+async function ensureCodexInstalled(): Promise<void> {
+  const found = await $`codex --version`.noThrow().quiet();
+  if (found.code === 0) {
+    return;
+  }
+  $.logStep("Installing OpenAI Codex CLI...");
+  await $`npm install -g @openai/codex`;
+}
+
+// `codex exec` does not read OPENAI_API_KEY on its own -- it needs credentials
+// stored via `codex login` first, otherwise its requests go out with no auth
+// header and the API returns 401. The key is piped over stdin so it never
+// appears in the process arguments.
+async function codexLogin(apiKey: string): Promise<void> {
+  $.logStep("Authenticating Codex with the OpenAI API key...");
+  await $`codex login --with-api-key`.stdinText(apiKey);
+}

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -4,6 +4,7 @@
  */
 import { $, CargoToml, semver } from "automation";
 import { Octokit } from "octokit";
+import { aiFixOxcUpdate } from "./ai_fix.ts";
 
 const rootDirPath = $.path(import.meta.dirname!).parentOrThrow();
 const cargoToml = new CargoToml(rootDirPath.join("Cargo.toml"));
@@ -26,9 +27,33 @@ const isPatchBump = cargoTomlVersion.version.major === latestTag.version.major
   && cargoTomlVersion.version.minor === latestTag.version.minor;
 cargoToml.replaceAll(cargoTomlVersion.tag, latestTag.tag);
 
-// run the tests
-$.logStep("Running tests...");
-await $`cargo test`;
+// Verify the update. A clean patch bump publishes exactly as before. A minor
+// bump always gets an AI review (Oxc may have added options without breaking
+// the build), and a patch bump that fails the checks gets an AI fix attempt.
+$.logStep("Running checks (test + clippy + wasm build)...");
+const checks = await runChecks();
+
+if (!isPatchBump || !checks.passed) {
+  if (checks.passed) {
+    $.logStep("Minor Oxc update — running AI review for new/changed options...");
+  } else {
+    $.logStep("Patch update failed the checks — running AI fix...");
+  }
+  await aiFixOxcUpdate({
+    isPatchBump,
+    fromVersion: cargoTomlVersion.tag,
+    toVersion: latestTag.tag,
+    checksPassed: checks.passed,
+    // hand the failing output to the AI so it can go straight to fixing
+    // instead of re-running the checks just to rediscover the errors.
+    checkOutput: checks.output,
+  });
+
+  // the AI must leave the project in a passing state, otherwise fail the
+  // workflow (nothing gets published and the maintainer is notified).
+  $.logStep("Re-running checks after AI changes...");
+  await assertChecks();
+}
 
 if (Deno.args.includes("--skip-publish")) {
   Deno.exit(0);
@@ -40,16 +65,59 @@ const message = `${isPatchBump ? "fix" : "feat"}: update to Oxc ${latestTag.tag}
 await $`git commit -m ${message}`;
 
 $.logStep("Bumping version in Cargo.toml...");
-cargoToml.bumpCargoTomlVersion(isPatchBump ? "patch" : "minor");
+// reload from disk before bumping: the AI may have edited Cargo.toml (e.g.
+// adding a new oxc crate dependency), and the in-memory copy loaded at startup
+// is stale. Writing the stale copy here would clobber those edits.
+const releaseCargoToml = new CargoToml(rootDirPath.join("Cargo.toml"));
+releaseCargoToml.bumpCargoTomlVersion(isPatchBump ? "patch" : "minor");
 
 // release
-const newVersion = cargoToml.version();
+const newVersion = releaseCargoToml.version();
 $.logStep(`Committing and publishing ${newVersion}...`);
 await $`git add .`;
 await $`git commit -m ${newVersion}`;
 await $`git push origin main`;
 await $`git tag ${newVersion}`;
 await $`git push origin ${newVersion}`;
+
+// the checks that must pass before publishing. clippy is included because
+// Codex runs it with warnings denied, so a clippy warning is as breaking as a
+// test failure, and the wasm release build is included because that is what
+// actually ships. `inheritPiped` + `captureCombined` streams the output to the
+// CI log live while also capturing it so a failure can be handed to the AI.
+async function runChecks(): Promise<{ passed: boolean; output: string }> {
+  const results = [];
+  for (const command of CHECK_COMMANDS) {
+    results.push(await capture(command()));
+  }
+  const failures = results.filter((r) => r.code !== 0);
+  return {
+    passed: failures.length === 0,
+    output: failures.map((r) => r.combined).join("\n\n"),
+  };
+}
+
+function capture(command: ReturnType<typeof $>) {
+  return command
+    .stdout("inheritPiped")
+    .stderr("inheritPiped")
+    .captureCombined()
+    .noThrow();
+}
+
+// same checks as `runChecks`, but throws on the first failure so the workflow
+// aborts before anything is committed, tagged, or published.
+async function assertChecks(): Promise<void> {
+  for (const command of CHECK_COMMANDS) {
+    await command();
+  }
+}
+
+const CHECK_COMMANDS = [
+  () => $`cargo test`,
+  () => $`cargo clippy --all-targets --all-features -- -D warnings`,
+  () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
+];
 
 function getCargoTomlTag(text: string) {
   const match = text.match(/git = \"https:\/\/github.com\/oxc-project\/oxc\", tag = \"([^\"]+)\"/);

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -87,7 +87,7 @@ await $`git push origin ${newVersion}`;
 // CI log live while also capturing it so a failure can be handed to the AI.
 async function runChecks(): Promise<{ passed: boolean; output: string }> {
   const results = [];
-  for (const command of CHECK_COMMANDS) {
+  for (const command of checkCommands()) {
     results.push(await capture(command()));
   }
   const failures = results.filter((r) => r.code !== 0);
@@ -108,16 +108,20 @@ function capture(command: ReturnType<typeof $>) {
 // same checks as `runChecks`, but throws on the first failure so the workflow
 // aborts before anything is committed, tagged, or published.
 async function assertChecks(): Promise<void> {
-  for (const command of CHECK_COMMANDS) {
+  for (const command of checkCommands()) {
     await command();
   }
 }
 
-const CHECK_COMMANDS = [
-  () => $`cargo test`,
-  () => $`cargo clippy --all-targets --all-features -- -D warnings`,
-  () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
-];
+// a function (not a top-level const) so it is hoisted -- `runChecks` is called
+// from top-level code above before a const declared here would be initialized.
+function checkCommands() {
+  return [
+    () => $`cargo test`,
+    () => $`cargo clippy --all-targets --all-features -- -D warnings`,
+    () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
+  ];
+}
 
 function getCargoTomlTag(text: string) {
   const match = text.match(/git = \"https:\/\/github.com\/oxc-project\/oxc\", tag = \"([^\"]+)\"/);


### PR DESCRIPTION
Ports the dprint-plugin-mago/biome AI update pipeline to this repo. When the daily `check_updates` job bumps the Oxc tag, breaking changes can be reconciled automatically instead of just failing.

## Flow (`scripts/update.ts`)
After applying the new Oxc tag:

| Case | Behavior |
|---|---|
| Patch, checks pass | Publishes exactly as before — no AI |
| Patch, checks fail | AI fixer → reviewer → re-run checks → publish |
| Minor (always) | AI reviewer/fixer (Oxc may add options without breaking the build) → re-run checks → publish |

**Checks** = `cargo test` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo build --target wasm32-unknown-unknown --features wasm --release`. Their combined output is captured (streamed live via `inheritPiped`) and handed to the fixer so it starts from the real errors.

## AI (`scripts/ai_fix.ts`)
1. **Fixer** — a Codex `exec` session reads the checked-out oxc source under `~/.cargo/git/checkouts`, wires new/renamed/removed `JsFormatOptions` fields through `configuration.rs`, `resolve_config.rs`, `format_text.rs`, and `deployment/schema.json`, and iterates until all checks pass. Model: `CODEX_MODEL` (`gpt-5.6-terra`).
2. **Reviewer** — a *separate* model (`REVIEW_MODEL`, `gpt-5.6-sol`) reviews the diff via Codex, investigating upstream, and returns a structured verdict. Blocking issues bounce back to the fixer (bounded). Not approved → throws, nothing publishes.

Details carried over from the earlier work: `codex login --with-api-key` (exec doesn't read `OPENAI_API_KEY` on its own); reviewer runs without the bubblewrap sandbox (it fails on GH runners) and is prompt-enforced read-only; `Cargo.toml` is reloaded from disk before the version bump so AI edits aren't clobbered; the AI leaves `README.md` alone.

Workflow (`check_updates.yml`, plain yaml here) installs the wasm target + Node and sets the OpenAI env vars.

## Before relying on it
- [x] Add the **`OPENAI_API_KEY`** repo secret.
- [x] Confirm the model IDs against a real breaking Oxc release (verified type-check/yaml-parse only).