### PR TITLE
chore: use npm plugin specifiers

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -254,14 +254,34 @@
               "selector": {
                 "description": "The import selector that must match.",
                 "type": "string",
-                "oneOf": [{ "const": "type" }, { "const": "side_effect_style" }, { "const": "side_effect" }, { "const": "style" }, { "const": "index" }, { "const": "sibling" }, { "const": "parent" }, { "const": "subpath" }, { "const": "internal" }, { "const": "builtin" }, { "const": "external" }, { "const": "import" }]
+                "oneOf": [
+                  { "const": "type" },
+                  { "const": "side_effect_style" },
+                  { "const": "side_effect" },
+                  { "const": "style" },
+                  { "const": "index" },
+                  { "const": "sibling" },
+                  { "const": "parent" },
+                  { "const": "subpath" },
+                  { "const": "internal" },
+                  { "const": "builtin" },
+                  { "const": "external" },
+                  { "const": "import" }
+                ]
               },
               "modifiers": {
                 "description": "Import modifiers that must all be present.",
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "oneOf": [{ "const": "side_effect" }, { "const": "type" }, { "const": "value" }, { "const": "default" }, { "const": "wildcard" }, { "const": "named" }]
+                  "oneOf": [
+                    { "const": "side_effect" },
+                    { "const": "type" },
+                    { "const": "value" },
+                    { "const": "default" },
+                    { "const": "wildcard" },
+                    { "const": "named" }
+                  ]
                 },
                 "default": []
               }
@@ -310,7 +330,11 @@
           "description": "How to format JSDoc comment blocks.",
           "type": "string",
           "default": "singleLine",
-          "oneOf": [{ "const": "singleLine", "description": "Convert to a single line when possible." }, { "const": "multiline", "description": "Always use multiple lines." }, { "const": "keep", "description": "Preserve the original line layout." }]
+          "oneOf": [
+            { "const": "singleLine", "description": "Convert to a single line when possible." },
+            { "const": "multiline", "description": "Always use multiple lines." },
+            { "const": "keep", "description": "Preserve the original line layout." }
+          ]
         },
         "separateTagGroups": {
           "description": "Add blank lines between different tag groups.",
@@ -346,7 +370,10 @@
           "description": "How JSDoc description lines wrap at the configured line width.",
           "type": "string",
           "default": "greedy",
-          "oneOf": [{ "const": "greedy", "description": "Always re-wrap text to fit the line width." }, { "const": "balance", "description": "Keep original line breaks when they fit." }]
+          "oneOf": [
+            { "const": "greedy", "description": "Always re-wrap text to fit the line width." },
+            { "const": "balance", "description": "Keep original line breaks when they fit." }
+          ]
         },
         "descriptionTag": {
           "description": "Emit an @description tag instead of an inline description.",

--- a/dprint.json
+++ b/dprint.json
@@ -12,10 +12,10 @@
     "**/target"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.95.13.wasm",
-    "https://plugins.dprint.dev/json-0.21.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.20.0.wasm",
-    "https://plugins.dprint.dev/toml-0.7.0.wasm",
-    "https://plugins.dprint.dev/exec-0.6.0.json@a054130d458f124f9b5c91484833828950723a5af3f8ff2bd1523bd47b83b364"
+    "npm:@dprint/typescript@0.96.1",
+    "npm:@dprint/json@0.23.0",
+    "npm:@dprint/markdown@0.22.1",
+    "npm:@dprint/toml@0.8.0",
+    "npm:@dprint/exec@0.7.3/plugin.json@704701df449dd7e942a71144773778ac529d68c2e4657bfc236d393b898b9a67"
   ]
 }

--- a/scripts/ai_fix.ts
+++ b/scripts/ai_fix.ts
@@ -55,8 +55,8 @@ export async function aiFixOxcUpdate(options: AiFixOptions): Promise<void> {
     if (round > REVIEW_MAX_ROUNDS) {
       const blocking = review.issues.filter((i) => i.severity === "blocking");
       throw new Error(
-        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n` +
-          blocking.map((i) => `  - ${i.description}`).join("\n"),
+        `AI reviewer did not approve after ${REVIEW_MAX_ROUNDS} refix round(s). Blocking issues:\n`
+          + blocking.map((i) => `  - ${i.description}`).join("\n"),
       );
     }
     $.logStep(`Reviewer requested changes — Codex refix round ${round}...`);


### PR DESCRIPTION
`dprint add <plugin>` now outputs npm specifiers, so update the config file to match.
