### PR TITLE
fix: upgrade to dprint-core 0.69.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dprint-core"
-version = "0.68.2"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb1dc2cac6929b352e64ee15d45cecb990f081eebbec99be0444edb01e642a8"
+checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
 dependencies = [
  "indexmap",
  "serde",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "dprint-plugin-oxc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "dprint-core",
  "dprint-development",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dprint-core"
-version = "0.69.0"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7554bfc77a03c35c5581d5f390b7f102c501e37841f7f43d29dd54a0b3c2284d"
+checksum = "67359cea061dd052fca921d3589a9ce59bc16fa23bfb9d06d5c669a1dbd23915"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ panic = "abort"
 wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
-dprint-core = { version = "0.69.0", default-features = false }
+dprint-core = { version = "0.69.1", default-features = false }
 oxc_allocator = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ panic = "abort"
 wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
-dprint-core = { version = "0.68.1", default-features = false }
+dprint-core = { version = "0.69.0", default-features = false }
 oxc_allocator = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }
 oxc_formatter_core = { git = "https://github.com/oxc-project/oxc", tag = "crates_v0.146.0" }


### PR DESCRIPTION
Upgrades `dprint-core` from 0.68.1 to 0.69.0.

No source changes were required — this plugin depends on `dprint-core` with `default-features = false` and doesn't use `formatting::ir_helpers::GeneratedValue`, so the new `is_known_multi_line` field doesn't affect it. Only `Cargo.toml` and `Cargo.lock` changed.

`cargo check --all-targets` and `cargo test` both pass (all 4 test binaries green, including the 14 spec tests).
