### PR TITLE
chore: use jsr:@dprint/automation 0.12.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git config user.name "${{ github.actor }}"
-          deno run -A https://raw.githubusercontent.com/dprint/automation/0.10.0/tasks/publish_release.ts --${{github.event.inputs.releaseKind}}
+          deno run -A jsr:@dprint/automation@0.12.2/tasks/publish-release --${{github.event.inputs.releaseKind}}

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,6 @@
 {
   "imports": {
-    "automation": "https://raw.githubusercontent.com/dprint/automation/0.10.0/mod.ts",
-    "automation/": "https://raw.githubusercontent.com/dprint/automation/0.10.0/",
+    "automation": "jsr:@dprint/automation@0.12.2",
     "octokit": "npm:octokit@^3.1"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,33 +1,35 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@david/dax@0.42.0": "0.42.0",
+    "jsr:@david/console-static-text@0.3": "0.3.4",
+    "jsr:@david/dax@0.45.0": "0.45.0",
     "jsr:@david/path@0.2": "0.2.0",
-    "jsr:@david/which@~0.4.1": "0.4.1",
-    "jsr:@std/assert@0.221": "0.221.0",
-    "jsr:@std/bytes@0.221": "0.221.0",
-    "jsr:@std/fmt@1": "1.0.8",
-    "jsr:@std/fs@1": "1.0.20",
-    "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/io@0.221": "0.221.0",
-    "jsr:@std/path@1": "1.1.3",
-    "jsr:@std/path@^1.1.3": "1.1.3",
-    "jsr:@std/semver@1": "1.0.7",
-    "jsr:@std/streams@0.221": "0.221.0",
-    "jsr:@std/yaml@1": "1.1.2",
-    "npm:octokit@^3.1.0": "3.2.2_@octokit+core@5.2.2"
+    "jsr:@david/which@~0.4.1": "0.4.2",
+    "jsr:@dprint/automation@0.12.2": "0.12.2",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/fmt@1": "1.0.10",
+    "jsr:@std/fs@1": "1.0.24",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/io@0.225": "0.225.3",
+    "jsr:@std/path@1": "1.1.6",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/semver@1": "1.0.8",
+    "npm:octokit@^3.1.0": "3.2.2"
   },
   "jsr": {
-    "@david/dax@0.42.0": {
-      "integrity": "0c547c9a20577a6072b90def194c159c9ddab82280285ebfd8268a4ebefbd80b",
+    "@david/console-static-text@0.3.4": {
+      "integrity": "1c596f500b075ff3c8bab1d328ca7148a88067fd9a506b16a73eeaf230c229fd"
+    },
+    "@david/dax@0.45.0": {
+      "integrity": "ac7565dc5c3e5be953a18b505e5dd0d8a30ed53656b65fd34a53bd8d2d5d6b1e",
       "dependencies": [
+        "jsr:@david/console-static-text",
         "jsr:@david/path",
         "jsr:@david/which",
         "jsr:@std/fmt",
         "jsr:@std/fs",
         "jsr:@std/io",
-        "jsr:@std/path@1",
-        "jsr:@std/streams"
+        "jsr:@std/path@1"
       ]
     },
     "@david/path@0.2.0": {
@@ -37,56 +39,50 @@
         "jsr:@std/path@1"
       ]
     },
-    "@david/which@0.4.1": {
-      "integrity": "896a682b111f92ab866cc70c5b4afab2f5899d2f9bde31ed00203b9c250f225e"
+    "@david/which@0.4.2": {
+      "integrity": "440ee262bc0673b57a39ad4d0dc5673e515ddd41c049a55b2588a0881e5d4a8c"
     },
-    "@std/assert@0.221.0": {
-      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
-    },
-    "@std/bytes@0.221.0": {
-      "integrity": "64a047011cf833890a4a2ab7293ac55a1b4f5a050624ebc6a0159c357de91966"
-    },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
-    },
-    "@std/fs@1.0.20": {
-      "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
+    "@dprint/automation@0.12.2": {
+      "integrity": "4065b01c0f5acadd9eed62eeadb58a8cde088c188f01f9bed32d48e3d0576881",
       "dependencies": [
-        "jsr:@std/internal",
-        "jsr:@std/path@^1.1.3"
+        "jsr:@david/dax",
+        "jsr:@std/semver"
       ]
     },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
-    "@std/io@0.221.0": {
-      "integrity": "faf7f8700d46ab527fa05cc6167f4b97701a06c413024431c6b4d207caa010da",
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1",
+      "dependencies": [
         "jsr:@std/bytes"
       ]
     },
-    "@std/path@1.1.3": {
-      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
-    "@std/semver@1.0.7": {
-      "integrity": "7d5f65391762dc4358abde80fc3354086ddb40101f140295e60f290c138887d0"
-    },
-    "@std/streams@0.221.0": {
-      "integrity": "47f2f74634b47449277c0ee79fe878da4424b66bd8975c032e3afdca88986e61",
-      "dependencies": [
-        "jsr:@std/io"
-      ]
-    },
-    "@std/yaml@1.1.2": {
-      "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
+    "@std/semver@1.0.8": {
+      "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     }
   },
   "npm": {
-    "@octokit/app@14.1.0_@octokit+core@5.2.2": {
+    "@octokit/app@14.1.0": {
       "integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
       "dependencies": [
         "@octokit/auth-app",
@@ -301,8 +297,8 @@
         "aggregate-error"
       ]
     },
-    "@types/aws-lambda@8.10.159": {
-      "integrity": "sha512-SAP22WSGNN12OQ8PlCzGzRCZ7QDCwI85dQZbmpz7+mAk+L7j+wI7qnvmdKh+o7A5LaOp6QnOZ2NJphAZQTTHQg=="
+    "@types/aws-lambda@8.10.162": {
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw=="
     },
     "@types/btoa-lite@1.0.2": {
       "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="
@@ -317,8 +313,8 @@
     "@types/ms@2.1.0": {
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
-    "@types/node@25.0.3": {
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+    "@types/node@26.1.1": {
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dependencies": [
         "undici-types"
       ]
@@ -414,7 +410,7 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "octokit@3.2.2_@octokit+core@5.2.2": {
+    "octokit@3.2.2": {
       "integrity": "sha512-7Abo3nADdja8l/aglU6Y3lpnHSfv0tw7gFPiqzry/yCU+2gTAX7R1roJ8hJrxIK+S1j+7iqRJXtmuHJ/UDsBhQ==",
       "dependencies": [
         "@octokit/app",
@@ -439,12 +435,12 @@
     "safe-buffer@5.2.1": {
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "semver@7.7.3": {
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+    "semver@7.8.5": {
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "bin": true
     },
-    "undici-types@7.16.0": {
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "universal-github-app-jwt@1.2.0": {
       "integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
@@ -460,16 +456,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   },
-  "remote": {
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/cargo.ts": "09cde3f879a9363a6d47bd2eebe7a78ed337172be5a133c72ba975674157c17d",
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/changelog.ts": "37fbdfcc59734192c3af45b9f60a495ff857528460ae8f30bfd0f504367ba2d0",
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/deps.ts": "4153d1d241c9d43b73bce43377b4e4ac828184e0dcef8d6c934c50c0dfaaefec",
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/hash.ts": "b81cab5700a6d7b6a0a4ff5b60bf0e26a2827eafd747ddd4c10bc6a4887d8d94",
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/mod.ts": "5f330d62cc675f3b6c464b186809d30df12830a1e4d4cbb64e1a494d058c6163",
-    "https://raw.githubusercontent.com/dprint/automation/0.10.0/process_plugin.ts": "232420b223baf7f21d31cfc103407ae229ec82b6e38676949994310ea9396909"
-  },
   "workspace": {
     "dependencies": [
+      "jsr:@dprint/automation@0.12.2",
       "npm:octokit@^3.1.0"
     ]
   }

--- a/scripts/generateReleaseNotes.ts
+++ b/scripts/generateReleaseNotes.ts
@@ -1,4 +1,4 @@
-import { generateChangeLog } from "automation/changelog.ts";
+import { generateChangeLog } from "automation";
 
 const version = Deno.args[0];
 const changelog = await generateChangeLog({


### PR DESCRIPTION
Moves the `automation` import off the pinned raw.githubusercontent URLs (0.10.0) and onto `jsr:@dprint/automation@0.12.2`.

The JSR package only exports `.` and `./tasks/publish-release`, so the `"automation/"` prefix mapping is gone and the release-notes script imports `generateChangeLog` from the root export instead of `automation/changelog.ts` — `mod.ts` re-exports `./changelog.ts`, so it's the same function. The release workflow's pinned `publish-release` task was bumped to match.

`deno.lock` was deleted and regenerated with `deno install`.
